### PR TITLE
modified scikit-learn version to compatible with Python 3.10 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==1.1.2
 sklearn
-scikit-learn==0.23.2
+scikit-learn == 1.1.3
 nltk==3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==2.2.2
 sklearn
 scikit-learn == 1.1.3
 nltk==3.5


### PR DESCRIPTION
As Part of PTO detector auto deployment project after cloning the repo when it started pip installing the requirements.txt it was throwing installation errors for python package scikit-learn==0.23.2 as this is not compatible with Python 3.10(latest version)

Changed the scikit-learn version which is compatible for 3.10 and ran it again and it installed successfully without any installation errors.

This version scikit-learn==0.23.2 is compatible with Python 3.7 where as scikit-learn == 1.1.3 is compatible for Python 3.10 so this PR is raised to change the version from scikit-learn==0.23.2 to scikit-learn == 1.1.3 in requirements.txt to support Python latest version.
